### PR TITLE
Make the codebase less toxic

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
It is prohibited to be white male supremacist.
The `main` branch cannot be `master`

See more details at https://github.com/github/renaming